### PR TITLE
Ensure that template is updated after rendering

### DIFF
--- a/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
+++ b/src/main/java/com/vaadin/flow/component/ironlist/IronList.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.JsonValue;
@@ -123,6 +124,8 @@ public class IronList<T> extends Component implements HasDataProvider<T>,
     private final Element template;
     private Renderer<T> renderer;
     private String originalTemplate;
+    private boolean rendererChanged;
+    private boolean templateUpdateRegistered;
 
     private final CompositeDataGenerator<T> dataGenerator = new CompositeDataGenerator<>();
     private Registration dataGeneratorRegistration;
@@ -217,15 +220,15 @@ public class IronList<T> extends Component implements HasDataProvider<T>,
 
         Rendering<T> rendering = renderer.render(getElement(),
                 dataCommunicator.getKeyMapper(), template);
-        originalTemplate = rendering.getTemplateElement()
-                .getProperty("innerHTML");
         if (rendering.getDataGenerator().isPresent()) {
             dataGeneratorRegistration = dataGenerator
                     .addDataGenerator(rendering.getDataGenerator().get());
         }
 
         this.renderer = renderer;
-        updateTemplateInnerHtml();
+
+        rendererChanged = true;
+        registerTemplateUpdate();
 
         getDataCommunicator().reset();
     }
@@ -255,7 +258,8 @@ public class IronList<T> extends Component implements HasDataProvider<T>,
         this.placeholderItem = placeholderItem;
         getElement().callFunction("$connector.setPlaceholderItem",
                 JsonSerializer.toJson(placeholderItem));
-        updateTemplateInnerHtml();
+
+        registerTemplateUpdate();
     }
 
     /**
@@ -268,7 +272,36 @@ public class IronList<T> extends Component implements HasDataProvider<T>,
         return placeholderItem;
     }
 
+    private void registerTemplateUpdate() {
+        if (templateUpdateRegistered) {
+            return;
+        }
+        templateUpdateRegistered = true;
+
+        /*
+         * The actual registration is done inside another beforeClientResponse
+         * registration to make sure it runs last, after ComponentRenderer and
+         * BasicRenderes have executed their rendering operations, which also
+         * happen beforeClientResponse and might be registered after this.
+         */
+        runBeforeClientResponse(
+                () -> runBeforeClientResponse(() -> updateTemplateInnerHtml()));
+    }
+
+    private void runBeforeClientResponse(Command command) {
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.getInternals().getStateTree()
+                        .beforeClientResponse(getElement().getNode(),
+                                context -> command.execute()));
+    }
+
     private void updateTemplateInnerHtml() {
+        templateUpdateRegistered = false;
+        if (rendererChanged) {
+            originalTemplate = template.getProperty("innerHTML");
+            rendererChanged = false;
+        }
+
         String placeholderTemplate;
         if (placeholderItem == null) {
             /*

--- a/src/test/java/com/vaadin/flow/component/ironlist/demo/IronListView.java
+++ b/src/test/java/com/vaadin/flow/component/ironlist/demo/IronListView.java
@@ -105,7 +105,7 @@ public class IronListView extends DemoView {
 
         public PersonCard(Person person) {
             setAlignItems(Alignment.CENTER);
-            getStyle().set("minWidth", "250px").set("padding", "10px")
+            getStyle().set("minWidth", "300px").set("padding", "10px")
                     .set("display", "flex");
 
             Image picture = new Image();

--- a/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListIT.java
+++ b/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListIT.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.ironlist.tests;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -29,6 +30,7 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -264,6 +266,48 @@ public class IronListIT extends AbstractComponentIT {
                 (Boolean) executeScript(
                         "return arguments[0].$connector._isUsingTheSameInstance",
                         list));
+    }
+
+    @Test
+    public void nativeButtonRenderer() {
+        List<TestBenchElement> buttons = $("iron-list").id("list-with-buttons")
+                .$("button").all();
+        Assert.assertEquals(3, buttons.size());
+        IntStream.range(0, 3).forEach(i -> {
+            Assert.assertEquals("Person " + (i + 1), buttons.get(i).getText());
+        });
+    }
+
+    @Test
+    public void numberRenderer() {
+        List<TestBenchElement> items = $("iron-list").id("list-with-numbers")
+                .$("span").all();
+        Assert.assertEquals(3, items.size());
+        IntStream.range(0, 3).forEach(i -> {
+            Assert.assertEquals("" + (i + 1), items.get(i).getText());
+        });
+    }
+
+    @Test
+    public void localDateRenderer() {
+        List<TestBenchElement> items = $("iron-list")
+                .id("list-with-local-dates").$("span").all();
+        Assert.assertEquals(3, items.size());
+
+        Assert.assertEquals("January 1, 2001", items.get(0).getText());
+        Assert.assertEquals("February 2, 2002", items.get(1).getText());
+        Assert.assertEquals("March 3, 2003", items.get(2).getText());
+    }
+
+    @Test
+    public void localDateTimeRenderer() {
+        List<TestBenchElement> items = $("iron-list")
+                .id("list-with-local-date-times").$("span").all();
+        Assert.assertEquals(3, items.size());
+
+        Assert.assertEquals("January 1, 2001 1:01 AM", items.get(0).getText());
+        Assert.assertEquals("February 2, 2002 2:02 AM", items.get(1).getText());
+        Assert.assertEquals("March 3, 2003 3:03 AM", items.get(2).getText());
     }
 
     private void assertItemsArePresent(WebElement list, int length) {

--- a/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListTestPage.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.html.Div;
@@ -55,7 +57,7 @@ public class IronListTestPage extends Div {
         }
     }
 
-    private static class Person {
+    public static class Person {
         private String name;
         private int age;
 
@@ -87,6 +89,7 @@ public class IronListTestPage extends Div {
         createLazyLoadingDataProvider();
         createTemplateWithEventHandlers();
         createListWithComponentRenderer();
+        createListWithComponentRendererWithBeansAndPlaceholder();
         createDetachableList();
         createListsWithBasicRenderers();
     }
@@ -258,7 +261,8 @@ public class IronListTestPage extends Div {
         IronList<String> list = new IronList<>();
         list.setHeight("100px");
 
-        List<String> items = Arrays.asList("Item 1", "Item 2", "Item 3");
+        List<String> items = IntStream.range(1, 101).mapToObj(i -> "Item " + i)
+                .collect(Collectors.toList());
 
         list.setRenderer(new ComponentRenderer<>(item -> {
             Label label = new Label(item);
@@ -268,6 +272,28 @@ public class IronListTestPage extends Div {
 
         list.setItems(items);
         list.setId("component-renderer");
+
+        add(list);
+    }
+
+    private void createListWithComponentRendererWithBeansAndPlaceholder() {
+        IronList<Person> list = new IronList<>();
+        list.setHeight("100px");
+
+        List<Person> people = createPeople(100);
+
+        list.setRenderer(new ComponentRenderer<Label, Person>(person -> {
+            Label label = new Label(person.getName());
+            label.addClassName("component-rendered");
+            return label;
+        }));
+
+        list.setItems(people);
+        list.setId("component-renderer-with-beans");
+
+        Person placeholder = new Person();
+        placeholder.setName("the-placeholder");
+        list.setPlaceholderItem(placeholder);
 
         add(list);
     }

--- a/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListTestPage.java
@@ -15,9 +15,12 @@
  */
 package com.vaadin.flow.component.ironlist.tests;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.html.Div;
@@ -27,6 +30,11 @@ import com.vaadin.flow.component.ironlist.IronList;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.data.provider.Query;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.renderer.LocalDateRenderer;
+import com.vaadin.flow.data.renderer.LocalDateTimeRenderer;
+import com.vaadin.flow.data.renderer.NativeButtonRenderer;
+import com.vaadin.flow.data.renderer.NumberRenderer;
+import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.data.renderer.TemplateRenderer;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
@@ -80,6 +88,7 @@ public class IronListTestPage extends Div {
         createTemplateWithEventHandlers();
         createListWithComponentRenderer();
         createDetachableList();
+        createListsWithBasicRenderers();
     }
 
     private void createListWithStrings() {
@@ -294,6 +303,42 @@ public class IronListTestPage extends Div {
         visible.setId("detachable-list-visible");
         add(container1, container2, detach, attach1, attach2, invisible,
                 visible);
+    }
+
+    private void createListsWithBasicRenderers() {
+        IronList<Person> listWithButtons = createIronList(
+                new NativeButtonRenderer<>(Person::getName));
+        listWithButtons.setId("list-with-buttons");
+
+        IronList<Person> listWithNumbers = createIronList(
+                new NumberRenderer<>(Person::getAge, Locale.ROOT));
+        listWithNumbers.setId("list-with-numbers");
+
+        IronList<Person> listWithLocalDates = createIronList(
+                new LocalDateRenderer<>(
+                        person -> LocalDate.of(2000 + person.getAge(),
+                                person.getAge(), person.getAge())));
+        listWithLocalDates.setId("list-with-local-dates");
+
+        IronList<Person> listWithLocalDateTimes = createIronList(
+                new LocalDateTimeRenderer<>(person -> LocalDateTime.of(
+                        2000 + person.getAge(), person.getAge(),
+                        person.getAge(), person.getAge(), person.getAge())));
+        listWithLocalDateTimes.setId("list-with-local-date-times");
+
+        add(listWithButtons, listWithNumbers, listWithLocalDates,
+                listWithLocalDateTimes);
+    }
+
+    private IronList<Person> createIronList(Renderer<Person> renderer) {
+        IronList<Person> list = new IronList<>();
+        list.setHeight("100px");
+
+        List<Person> people = createPeople(3);
+        list.setItems(people);
+
+        list.setRenderer(renderer);
+        return list;
     }
 
     private List<Person> createPeople(int amount) {

--- a/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListViewIT.java
+++ b/src/test/java/com/vaadin/flow/component/ironlist/tests/IronListViewIT.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -144,7 +145,10 @@ public class IronListViewIT extends TabbedComponentDemoTest {
                 .id("list-of-people-with-dataprovider-and-component-renderer"));
 
         List<WebElement> content = list
-                .findElements(By.cssSelector("vaadin-vertical-layout"));
+                .findElements(By.cssSelector("vaadin-vertical-layout")).stream()
+                .filter(element -> !element.getAttribute("innerHTML")
+                        .contains("-----")) // placeholders
+                .collect(Collectors.toList());
 
         waitUntil(driver -> content.get(0).getAttribute("disabled") != null);
         Optional<WebElement> notDisabled = content.stream()


### PR DESCRIPTION
Fixes #26, fixes #27 and fixes #54: Handling the template's innerHTML
after ComponentRenderer's render() call makes it use placeholder item
correctly (or the empty placeholder if none is set). So the component
no longer gets 0-height items, which made it try to load everything
at once.

Fixes #55: The BasicRenderers also handle rendering in
beforeClientResponse. Because of this the IronList didn't wrap the items
in spans like it normally would. The web component expects there to be
some element in the template, so it broke when setting just string
values inside.

Added tests for the fixed tickets:
- BasicRenderers work
- Lazy loading works also when using ComponentRenderer (doesn't load everything at once)
- Placeholder works with ComponentRenderer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-iron-list-flow/56)
<!-- Reviewable:end -->
