### PR TITLE
Fix missing Lumo frontend files for RC1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ target/
 .settings
 .classpath
 
+# IntelliJ files
+*.iml
+.idea/
+
 # Selenium
 error-screenshots
 reference-screenshots

--- a/vaadin-iron-list-flow-demo/src/main/java/com/vaadin/flow/component/ironlist/demo/IronListView.java
+++ b/vaadin-iron-list-flow-demo/src/main/java/com/vaadin/flow/component/ironlist/demo/IronListView.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import com.github.javafaker.Faker;
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Label;
@@ -43,6 +44,8 @@ import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 
+// FIXME remove once https://github.com/vaadin/flow/pull/5660 is available 
+@NpmPackage(value = "@vaadin/vaadin-lumo-styles", version = "1.5.0")
 @Route("iron-list")
 public class IronListView extends DemoView {
 


### PR DESCRIPTION
To be removed once Flow 2.0 RC2 is available with the correct fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-iron-list-flow/81)
<!-- Reviewable:end -->
