### PR TITLE
Fix wrong tb-element artifact name

### DIFF
--- a/vaadin-iron-list-flow-integration-tests/pom.xml
+++ b/vaadin-iron-list-flow-integration-tests/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-iron-list-flow-testbench</artifactId>
+            <artifactId>vaadin-iron-list-testbench</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Had been forgotten to update in IT module

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-iron-list-flow/82)
<!-- Reviewable:end -->
